### PR TITLE
Various animated cursor fixes

### DIFF
--- a/wayland/Display.hpp
+++ b/wayland/Display.hpp
@@ -30,6 +30,7 @@ private:
     WaylandPointer<wl_compositor> _compositor;
     WaylandPointer<xdg_wm_base> _wm_base;
 
+    std::unique_ptr<CursorManagerBase> _cursor_manager;
     std::forward_list<Seat> _seats;
 
     // Optional protocols
@@ -37,6 +38,5 @@ private:
     WaylandPointer<wp_content_type_manager_v1> _content_type_manager; 
     WaylandPointer<zxdg_decoration_manager_v1> _decoration_manager;
 
-    std::unique_ptr<CursorManagerBase> _cursor_manager;
     XkbPointer<xkb_context> _xkb_context;
 };

--- a/wayland/cursor/theme/ThemeCursor.cpp
+++ b/wayland/cursor/theme/ThemeCursor.cpp
@@ -15,7 +15,11 @@ ThemeCursor::~ThemeCursor() {
 void ThemeCursor::set_pointer(uint32_t serial) {
     _serial = serial;
     _thread_status.clear(std::memory_order_release);
-    _thread = std::thread(&ThemeCursor::thread_entry, this);
+
+    wl_pointer_set_cursor(_pointer, _serial, _surface.get(), _cursor->images[0]->hotspot_x, _cursor->images[0]->hotspot_y);
+    if (_cursor->image_count > 0) {
+        _thread = std::thread(&ThemeCursor::thread_entry, this);
+    }
 }
 
 void ThemeCursor::unset_pointer(uint32_t serial) {
@@ -25,16 +29,12 @@ void ThemeCursor::unset_pointer(uint32_t serial) {
 
 void ThemeCursor::thread_entry() noexcept {
     uint32_t image_index = 0;
-    
-    auto *image = _cursor->images[image_index];
-    wl_pointer_set_cursor(_pointer, _serial, _surface.get(), image->hotspot_x, image->hotspot_y);
-
     while (!_thread_status.test(std::memory_order_relaxed)) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(image->delay));
+        const auto *old_image = _cursor->images[image_index];
+        std::this_thread::sleep_for(std::chrono::milliseconds(old_image->delay));
 
-        const auto *old_image = image;
         image_index = (image_index + 1) % _cursor->image_count;
-        image = _cursor->images[image_index];
+        auto *image = _cursor->images[image_index];
 
         wl_surface_attach(_surface.get(), wl_cursor_image_get_buffer(image), old_image->hotspot_x - image->hotspot_x, old_image->hotspot_y - image->hotspot_y);
         wl_surface_damage_buffer(_surface.get(), 0, 0, image->width, image->height);

--- a/wayland/cursor/theme/ThemeCursor.cpp
+++ b/wayland/cursor/theme/ThemeCursor.cpp
@@ -25,14 +25,19 @@ void ThemeCursor::unset_pointer(uint32_t serial) {
 
 void ThemeCursor::thread_entry() noexcept {
     uint32_t image_index = 0;
-    while (!_thread_status.test(std::memory_order_relaxed)) {
-        auto *image = _cursor->images[image_index];
-        wl_surface_attach(_surface.get(), wl_cursor_image_get_buffer(image), image->width, image->height);
-        wl_surface_damage_buffer(_surface.get(), 0, 0, image->width, image->height);
-        wl_pointer_set_cursor(_pointer, _serial, _surface.get(), image->hotspot_x, image->hotspot_y);
-        wl_surface_commit(_surface.get());
+    
+    auto *image = _cursor->images[image_index];
+    wl_pointer_set_cursor(_pointer, _serial, _surface.get(), image->hotspot_x, image->hotspot_y);
 
+    while (!_thread_status.test(std::memory_order_relaxed)) {
         std::this_thread::sleep_for(std::chrono::milliseconds(image->delay));
+
+        const auto *old_image = image;
         image_index = (image_index + 1) % _cursor->image_count;
+        image = _cursor->images[image_index];
+
+        wl_surface_attach(_surface.get(), wl_cursor_image_get_buffer(image), old_image->hotspot_x - image->hotspot_x, old_image->hotspot_y - image->hotspot_y);
+        wl_surface_damage_buffer(_surface.get(), 0, 0, image->width, image->height);
+        wl_surface_commit(_surface.get());
     }
 }


### PR DESCRIPTION
Don't crash due to a race between CursorManager destruction and seat (and thus Cursor) destruction.
Don't bother with a threat to animate 1-image cursors
Set hotspot correctly if it changes.